### PR TITLE
fix: Delete the sample config.txt file

### DIFF
--- a/debian/boot/config.txt
+++ b/debian/boot/config.txt
@@ -1,5 +1,0 @@
-# Uncomment this to enable infrared communication.
-dtdebug=0
-#dtoverlay=ion_resize,size=0x40000000
-#dtoverlay=dtoverlay_test
-


### PR DESCRIPTION
Summary:
    Delete the config.txt file to prevent users from overwriting
    config.txt after updating hobot-boot. Please refer to the
    documentation for all uses of config.txt.